### PR TITLE
Remove "text-transform: capitalize" from button

### DIFF
--- a/emailBuilder/Assets/Components/button.html
+++ b/emailBuilder/Assets/Components/button.html
@@ -1,7 +1,7 @@
 <div style="font-family:'Lato', Tahoma, Verdana, Segoe, sans-serif;line-height:120%;color:#000000; padding-right: 20px; padding-left: 20px; padding-top: 10px; padding-bottom: 10px;">	
         <div style="font-size:12px;line-height:14px;color:#000000;font-family:'Lato', Tahoma, Verdana, Segoe, sans-serif;text-align:left;">
             <p style="margin: 0;font-size: 12px;line-height: 14px;text-align:{align}">
-                <a href="{target}" target="_blank" style="display: inline-block; color: #ffffff; background-color: {color}; border: solid 1px #f0f0f0; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-transform: capitalize; border-color: #777;">
+                <a href="{target}" target="_blank" style="display: inline-block; color: #ffffff; background-color: {color}; border: solid 1px #f0f0f0; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; border-color: #777;">
                             {content}
                 </a>
             </p>


### PR DESCRIPTION
Currently it causes button content like "Foo bar" to be displayed as "Foo Bar".

`text-transform: uppercase` would be another option to get "FOO BAR". But in my eyes this wouldn't make sense to use as a default value as well.